### PR TITLE
[13.0][FIX] hr_holidays_public: Fix number_of_days in leaves when contain holiday in leave and hour start from resource calendar in 00:01

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -1,6 +1,7 @@
 # Copyright 2015 2011,2013 Michael Telahun Makonnen <mmakonnen@gmail.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+import datetime
 from datetime import date
 
 from odoo import SUPERUSER_ID, _, api, fields, models
@@ -55,15 +56,23 @@ class HrHolidaysPublic(models.Model):
 
     @api.model
     @api.returns("hr.holidays.public.line")
-    def get_holidays_list(self, year, employee_id=None):
+    def get_holidays_list(
+        self, year=None, start_dt=None, end_dt=None, employee_id=None
+    ):
         """
         Returns recordset of hr.holidays.public.line
         for the specified year and employee
-        :param year: year as string
+        :param year: year as string (optional if start_dt and end_dt defined)
+        :param start_dt: start_dt as date
+        :param end_dt: end_dt as date
         :param employee_id: ID of the employee
         :return: recordset of hr.holidays.public.line
         """
-        holidays_filter = [("year", "=", year)]
+        if not start_dt and not end_dt:
+            start_dt = datetime.date(year, 1, 1)
+            end_dt = datetime.date(year, 12, 31)
+        years = list(range(start_dt.year, end_dt.year + 1))
+        holidays_filter = [("year", "in", years)]
         employee = False
         if employee_id:
             employee = self.env["hr.employee"].browse(employee_id)
@@ -88,6 +97,8 @@ class HrHolidaysPublic(models.Model):
             ]
         else:
             states_filter.append(("state_ids", "=", False))
+        states_filter.append(("date", ">=", start_dt))
+        states_filter.append(("date", "<=", end_dt))
         hhplo = self.env["hr.holidays.public.line"]
         holidays_lines = hhplo.search(states_filter)
         return holidays_lines
@@ -101,7 +112,7 @@ class HrHolidaysPublic(models.Model):
         :return: bool
         """
         holidays_lines = self.get_holidays_list(
-            selected_date.year, employee_id=employee_id
+            year=selected_date.year, employee_id=employee_id
         )
         if holidays_lines:
             hol_date = holidays_lines.filtered(lambda r: r.date == selected_date)

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -1,11 +1,7 @@
 # Copyright 2017-2018 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Brainbean Apps
+# Copyright 2021 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
-
-from datetime import datetime, time
-
-from dateutil import rrule
-from pytz import timezone
 
 from odoo import models
 
@@ -15,77 +11,35 @@ from odoo.addons.resource.models.resource import Intervals
 class ResourceCalendar(models.Model):
     _inherit = "resource.calendar"
 
-    def _public_holidays_leave_intervals(self, start_dt, end_dt, employee_id, tz):
-        """Get the public holidays for the current employee and given dates in
-        the format expected by resource methods.
-
-        :param: start_dt: Initial datetime.
-        :param: end_dt: End datetime.
-        :param: employee_id: Employee ID. It can be false.
-        :return: List of tuples with (start_date, end_date) as elements.
-        """
-        HrHolidaysPublic = self.env["hr.holidays.public"]
-
-        leaves = []
-        if start_dt.year != end_dt.year:
-            # This fixes the case of leave request asked over 2 years.
-            #
-            # adding 1 year to end_dt for rrule to retrieve correct years for
-            # public holidays to work
-            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2020-01-05)
-            # gives [2019]
-            # rrule.rrule(rrule.YEARLY, dtstart=2019-12-22, until=2021-01-05)
-            # gives [2019, 2020]
-            end_dt = end_dt.replace(year=end_dt.year + 1)
-
-        for day in rrule.rrule(rrule.YEARLY, dtstart=start_dt, until=end_dt):
-            lines = HrHolidaysPublic.get_holidays_list(
-                day.year, employee_id=employee_id
+    def _attendance_intervals_batch_exclude_public_holidays(
+        self, start_dt, end_dt, intervals, resources, tz
+    ):
+        list_by_dates = (
+            self.env["hr.holidays.public"]
+            .get_holidays_list(
+                start_dt=start_dt.date(),
+                end_dt=end_dt.date(),
+                employee_id=self.env.context.get("employee_id", False),
             )
-            # In some cases, an error appears about mixing 2 models
-            # (hr.holidays.public.line + resource.calendar.leaves)
-            # in _leave_intervals or _leave_intervals_batch functions
-            # It only happen when both holidays and leaves exist.
-            # The solution is to pass an empty leave in the tuple instead
-            # of the public holiday line record, as this element has no
-            # further use except the union operation.
-            resource_leave_model = self.env["resource.calendar.leaves"]
-            for line in lines:
-                leaves.append(
-                    (
-                        datetime.combine(line.date, time.min).replace(tzinfo=tz),
-                        datetime.combine(line.date, time.max).replace(tzinfo=tz),
-                        resource_leave_model,
-                    )
-                )
-        return Intervals(leaves)
-
-    def _leave_intervals(self, start_dt, end_dt, resource=None, domain=None, tz=None):
-        """DEPRECATED since odoo/odoo#51542, but left as is for retro-compatibility"""
-        # TODO: To be removed in v14 if not used in any place
-        res = super()._leave_intervals(
-            start_dt=start_dt, end_dt=end_dt, resource=resource, domain=domain, tz=tz
+            .mapped("date")
         )
-        if self.env.context.get("exclude_public_holidays"):
-            tz = tz if tz else timezone((resource or self).tz)
-            public_holidays = self._public_holidays_leave_intervals(
-                start_dt, end_dt, self.env.context.get("employee_id", False), tz
-            )
-            res = res | public_holidays
-        return res
+        for resource in resources:
+            interval_resource = intervals[resource.id]
+            attendances = []
+            for attendance in interval_resource._items:
+                if attendance[0].date() not in list_by_dates:
+                    attendances.append(attendance)
+            intervals[resource.id] = Intervals(attendances)
+        return intervals
 
-    def _leave_intervals_batch(
+    def _attendance_intervals_batch(
         self, start_dt, end_dt, resources=None, domain=None, tz=None
     ):
-        """Inject public holidays in the leaves got for computations."""
-        res = super()._leave_intervals_batch(
+        res = super()._attendance_intervals_batch(
             start_dt=start_dt, end_dt=end_dt, resources=resources, domain=domain, tz=tz
         )
         if self.env.context.get("exclude_public_holidays"):
-            tz = tz if tz else timezone((resources[:1] or self).tz)
-            public_holidays = self._public_holidays_leave_intervals(
-                start_dt, end_dt, self.env.context.get("employee_id", False), tz
+            return self._attendance_intervals_batch_exclude_public_holidays(
+                start_dt, end_dt, res, resources, tz
             )
-            for key in res:
-                res[key] = res[key] | public_holidays
         return res


### PR DESCRIPTION
Fix `number_of_days` in leaves when contain holiday in leave and hour start from resource calendar in 00:01.
It's a problem according to timezone.

Steps to reproduce:
- Create 2021-05-01 in public holidays.
- Create new working hours according to Abigail Peterson called "_Tuesday - Saturday 00:01 - 08:01_" and set details.
- Go to Time off > Managers > To aprrove > Time Off and create new records:
- Record A: Michel Admin, Paid Time Off, from 2021-04-27 to 2021-05-01.
- Record B: Abigail Peterson, Paid Time Off, from 2021-04-27 to 2021-05-01.

In some examples set duration to 5 days.

Please @pedrobaeza can you review it?

@Tecnativa TT29189