### PR TITLE
[13.0][FIX] hr_holidays_public: Prevent error in leave form without employee set yet

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -38,7 +38,7 @@ class ResourceCalendar(models.Model):
         res = super()._attendance_intervals_batch(
             start_dt=start_dt, end_dt=end_dt, resources=resources, domain=domain, tz=tz
         )
-        if self.env.context.get("exclude_public_holidays"):
+        if self.env.context.get("exclude_public_holidays") and resources:
             return self._attendance_intervals_batch_exclude_public_holidays(
                 start_dt, end_dt, res, resources, tz
             )


### PR DESCRIPTION
Prevent error in leave form without employee set yet.

Steps to reproduce:
- Create public hoilidays (26/04/2021).
- Go to Time Off > Managers > Time Off and try to create new record, set date from 26/04/2021 to 29/04/2021 and empty employee selector.

Please @pedrobaeza and @Yajo can you review it?

@Tecnativa TT29351