### PR TITLE
[13.0][FIX] hr_holidays_natural_period: Prevent error in leave form without employee set yet

### DIFF
--- a/hr_holidays_natural_period/models/resource_calendar.py
+++ b/hr_holidays_natural_period/models/resource_calendar.py
@@ -21,7 +21,7 @@ class ResourceCalendar(models.Model):
         return False
 
     def _natural_period_intervals_batch(self, start_dt, end_dt, intervals, resources):
-        for resource in resources:
+        for resource in resources or []:
             interval_resource = intervals[resource.id]
             tz = timezone(resource.tz)
             attendances = []


### PR DESCRIPTION
Prevent error in leave form without employee set yet.

Steps to reproduce:
- Create public hoilidays (26/04/2021).
- Go to Time Off > Managers > Time Off and try to create new record, set date from 26/04/2021 to 29/04/2021 and empty employee selector.

It's similar to https://github.com/OCA/hr-holidays/pull/25

Please @pedrobaeza and @joao-p-marques  can you review it?

@Tecnativa TT30977