### PR TITLE
[14.0][Fix] hr_holiday_public: Set exclude_public_holidays context on _compute_number_of_hours_display

### DIFF
--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -19,6 +19,16 @@ class HrLeave(models.Model):
             date_from, date_to, employee_id
         )
 
+    @api.depends("number_of_days")
+    def _compute_number_of_hours_display(self):
+        if self.holiday_status_id.exclude_public_holidays or not self.holiday_status_id:
+            instance = self.with_context(
+                exclude_public_holidays=True, employee_id=self.employee_id.id
+            )
+        else:
+            instance = self
+        return super(HrLeave, instance)._compute_number_of_hours_display()
+
     @api.model
     def get_unusual_days(self, date_from, date_to=None):
         res = super().get_unusual_days(date_from, date_to=date_to)

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -176,3 +176,18 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
         )
         leave_request._compute_number_of_days()
         self.assertEqual(leave_request.number_of_days, 5)
+
+    def test_number_of_hours_excluding_employee_2(self):
+        self.holiday_type.request_unit = "hour"
+        leave_request = self.HrLeave.new(
+            {
+                "date_from": "1946-12-23 00:00:00",  # Monday
+                "date_to": "1946-12-29 23:59:59",  # Sunday
+                "holiday_status_id": self.holiday_type.id,
+                "employee_id": self.employee_2.id,
+            }
+        )
+        leave_request.action_validate()
+
+        self.assertEqual(leave_request.number_of_days, 2)
+        self.assertEqual(leave_request.number_of_hours_display, 16)


### PR DESCRIPTION
Holiday `Duration (hours)` is not taking in consideration employee bank holidays.

### Steps to reproduce:
- Create an employee that lives in the country A / state B
- Create a public bank holiday (01/12/1946) on the country A / state B and validate it 
=> 01/12/1946 is not taken in consideration to calculate `number_of_hours_display`

### Context
The issue is that the method `get_holidays_list` is expecting to receive employee_id as a parameter: https://github.com/OCA/hr-holidays/blob/100d17e69e0fca176f7fef07e0602a3c7a14b58e/hr_holidays_public/models/hr_holidays_public.py#L61

The value of this paramenter is passed here: 
https://github.com/OCA/hr-holidays/blob/100d17e69e0fca176f7fef07e0602a3c7a14b58e/hr_holidays_public/models/resource_calendar.py#L23 

But employee_id and exclude_public_holidays not passed in the context in the original code.
