### PR TITLE
[14.0][Fix] hr_holiday_public: Work time per day not excluding holidays

### DIFF
--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -8,6 +8,17 @@ from odoo import api, fields, models
 class HrLeave(models.Model):
     _inherit = "hr.leave"
 
+    def action_validate(self):
+        """Inject the needed context for excluding public holidays (if applicable) on the
+        actions derived from this validation. This is required for example for
+        `project_timesheet_holidays` for not generating the timesheet on the public holiday.
+        Unfortunately, no regression test can be added, being in a separate module."""
+        if self.holiday_status_id.exclude_public_holidays or not self.holiday_status_id:
+            self = self.with_context(
+                employee_id=self.employee_id.id, exclude_public_holidays=True
+            )
+        return super(HrLeave, self).action_validate()
+
     def _get_number_of_days(self, date_from, date_to, employee_id):
         if self.holiday_status_id.exclude_public_holidays or not self.holiday_status_id:
             instance = self.with_context(


### PR DESCRIPTION
### Context
The mehod `resource_calendar.list_work_time_per_day(self, from_datetime, to_datetime, calendar=None, domain=None)`  returns a list of tuples (day, hours). Working days and number of hours to work on that day.
The issue is that is not excluding public holidays.

Steps to reproduce:
- Please check the unit test => Without the fixing, `list_work_time_per_day` will return 3 working days when is suposed to be 2.

This has an impact for example when module `project_timesheet_holidays` is installed. Normally with that module timesheet lines of type holidays are created  when a `hr.leave` is validated. But with that bug, also timesheet lines are created in public holidays. The method `list_work_time_per_day` is not propagating context variables `exclude_public_holidays` and `employee_id`.