### PR TITLE
[13.0][FIX] hr_holidays_natural_period: Fix _exist_interval_in_date() function + Impove tests.

### DIFF
--- a/hr_holidays_natural_period/models/resource_calendar.py
+++ b/hr_holidays_natural_period/models/resource_calendar.py
@@ -16,7 +16,7 @@ class ResourceCalendar(models.Model):
 
     def _exist_interval_in_date(self, intervals, date):
         for interval in intervals:
-            if interval[0].date == date:
+            if interval[0].date() == date:
                 return True
         return False
 


### PR DESCRIPTION
Previously, the `_exist_interval_in_date()` function always returned `False`, which always created a new interval.
Although this was totally incorrect, it was detected in a real use case when there were working days and holidays in the date range causing incorrect overtime.

Please @pedrobaeza and @chienandalu can you review it?

@Tecnativa TT33779