### PR TITLE
[15.0][FIX] hr_holidays_public: wrong computation in case resources in different countries

### DIFF
--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -14,7 +14,7 @@
     "Odoo Community Association (OCA),",
     "summary": "Manage Public Holidays",
     "website": "https://github.com/OCA/hr-holidays",
-    "depends": ["hr_holidays"],
+    "depends": ["hr_holidays", "hr_attendance"],
     "data": [
         "data/data.xml",
         "security/ir.model.access.csv",

--- a/hr_holidays_public/__manifest__.py
+++ b/hr_holidays_public/__manifest__.py
@@ -14,7 +14,7 @@
     "Odoo Community Association (OCA),",
     "summary": "Manage Public Holidays",
     "website": "https://github.com/OCA/hr-holidays",
-    "depends": ["hr_holidays", "hr_attendance"],
+    "depends": ["hr_holidays"],
     "data": [
         "data/data.xml",
         "security/ir.model.access.csv",

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -15,20 +15,46 @@ class ResourceCalendar(models.Model):
     def _attendance_intervals_batch_exclude_public_holidays(
         self, start_dt, end_dt, intervals, resources, tz
     ):
-        list_by_dates = (
-            self.env["hr.holidays.public"]
-            .get_holidays_list(
-                start_dt=start_dt.date(),
-                end_dt=end_dt.date(),
-                employee_id=self.env.context.get("employee_id", False),
+        holidays_by_country = {
+            False: set(
+                self.env["hr.holidays.public"]
+                .get_holidays_list(
+                    start_dt=start_dt.date(),
+                    end_dt=end_dt.date(),
+                    employee_id=self.env.context.get("employee_id", False),
+                )
+                .mapped("date")
             )
-            .mapped("date")
-        )
+        }
+        if resources:
+            employees = self.env["hr.employee.public"].search(
+                [("resource_id", "in", resources.ids)]
+            )
+            resource_country = {}
+            for employee in employees:
+                country = employee.address_id.country_id
+                resource_country[employee.resource_id.id] = country.id
+                if country.id not in holidays_by_country:
+                    holidays_by_country[country.id] = set(
+                        self.env["hr.holidays.public"]
+                        .get_holidays_list(
+                            start_dt=start_dt.date(),
+                            end_dt=end_dt.date(),
+                            employee_id=employee.id,
+                        )
+                        .mapped("date")
+                    )
+        # even if employees and resource_country are empty
+        # we still process holidays, so provide defaults
         for resource in resources:
-            interval_resource = intervals[resource.id]
+            interval_resource = intervals.get(
+                resource.id, Intervals(self.env["hr.attendance"])
+            )
             attendances = []
+            country = resource_country.get(resource.id, self.env["res.country"])
+            holidays = holidays_by_country.get(country, set())
             for attendance in interval_resource._items:
-                if attendance[0].date() not in list_by_dates:
+                if attendance[0].date() not in holidays:
                     attendances.append(attendance)
             intervals[resource.id] = Intervals(attendances)
         return intervals

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -23,6 +23,7 @@ class ResourceCalendar(models.Model):
                     end_dt=end_dt.date(),
                     employee_id=self.env.context.get("employee_id", False),
                 )
+                .filtered(lambda rec: not rec.year_id.country_id)
                 .mapped("date")
             )
         }
@@ -47,9 +48,7 @@ class ResourceCalendar(models.Model):
         # even if employees and resource_country are empty
         # we still process holidays, so provide defaults
         for resource in resources:
-            interval_resource = intervals.get(
-                resource.id, Intervals(self.env["hr.attendance"])
-            )
+            interval_resource = intervals.get(resource.id, Intervals())
             attendances = []
             country = resource_country.get(resource.id, self.env["res.country"])
             holidays = holidays_by_country.get(country, set())


### PR DESCRIPTION
Fix an issue in hr_holidays_public where
resource.calendar::_attendance_intervals_batch_exclude_public_holidays
would return a wrong result when called with multiple resources working
in different countries.

The original implementation uses a context key employee_id to find the
employee, which only allows this method to be called with a single
employee. The fix searches for the employees related to the resources
passed in arguments, and default to the context key if there are no
provided resources.

Also rework the implementation to use a python set rather than a list
for faster in test.