### PR TITLE
[15.0][FIX] Public vacations cannot be saved if variable_date is False

### DIFF
--- a/hr_holidays_public/views/hr_holidays_public_view.xml
+++ b/hr_holidays_public/views/hr_holidays_public_view.xml
@@ -30,6 +30,7 @@
                             <field
                                 name="date"
                                 attrs="{'readonly':[['variable_date', '=', False]]}"
+                                force_save="1"
                             />
                             <field name="name" />
                             <field


### PR DESCRIPTION
In https://github.com/OCA/hr-holidays/issues/45#issue-1270315456, are the steps to reproduce the problem.