### PR TITLE
[16.0][FIX] - hr_public_holidays: holidays table is not fully visible in form view

### DIFF
--- a/hr_holidays_public/views/hr_holidays_public_view.xml
+++ b/hr_holidays_public/views/hr_holidays_public_view.xml
@@ -24,24 +24,23 @@
                         <!-- Left empty for extensions -->
                     </group>
                 </group>
-                <group string="Public Holidays" name="group_detail">
-                    <field name="line_ids" nolabel="1">
-                        <tree editable="top">
-                            <field
-                                name="date"
-                                attrs="{'readonly':[['variable_date', '=', False]]}"
-                                force_save="1"
-                            />
-                            <field name="name" />
-                            <field
-                                name="state_ids"
-                                widget="many2many_tags"
-                                domain="[('country_id','=',parent.country_id)]"
-                            />
-                            <field name="variable_date" />
-                        </tree>
-                    </field>
-                </group>
+                <separator string="Public Holidays" name="group_detail" />
+                <field name="line_ids" nolabel="1">
+                    <tree editable="top">
+                        <field
+                            name="date"
+                            attrs="{'readonly':[['variable_date', '=', False]]}"
+                            force_save="1"
+                        />
+                        <field name="name" />
+                        <field
+                            name="state_ids"
+                            widget="many2many_tags"
+                            domain="[('country_id','=',parent.country_id)]"
+                        />
+                        <field name="variable_date" />
+                    </tree>
+                </field>
             </form>
         </field>
     </record>


### PR DESCRIPTION
public holiday days table is not fully visible

![image](https://user-images.githubusercontent.com/12665409/229078903-03ab7509-18c9-4ab8-b78e-2a7bda02f70d.png)
