### PR TITLE
[15.0][FIX] hr_holidays_public: allow to search holidays to non hr users

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -85,7 +85,7 @@ class HrHolidaysPublic(models.Model):
                 )
             else:
                 holidays_filter.append(("country_id", "=", False))
-        pholidays = self.search(holidays_filter)
+        pholidays = self.sudo().search(holidays_filter)
         if not pholidays:
             return self.env["hr.holidays.public.line"]
 
@@ -101,7 +101,7 @@ class HrHolidaysPublic(models.Model):
         states_filter.append(("date", ">=", start_dt))
         states_filter.append(("date", "<=", end_dt))
         hhplo = self.env["hr.holidays.public.line"]
-        holidays_lines = hhplo.search(states_filter)
+        holidays_lines = hhplo.sudo().search(states_filter)
         return holidays_lines
 
     @api.model


### PR DESCRIPTION
When users with no privileges run the method get_holidays_list an access error is raised. This won't happen with only this module installed but on modules built on top of this one this is possible and the fix won't hurt IMHO.

@ForgeFlow