### PR TITLE
[FIX] hr_holidays_public: Don't populate partner_ids on calendar event

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -217,6 +217,7 @@ class HrHolidaysPublicLine(models.Model):
             "user_id": SUPERUSER_ID,
             "privacy": "confidential",
             "show_as": "busy",
+            "partner_ids": [],
         }
         if categ_id:
             meeting_values.update({"categ_ids": [(6, 0, categ_id.ids)]})


### PR DESCRIPTION
When you configure a public holiday in `hr.holidays.public.line` then a `calendar.event` calendar event linked to this public holiday (`meeting_id` field in `hr.holidays.public.line`) is automatically created with the `partner_ids` field filled in by the partner of the user who created the holiday.

This PR modifies so that when creating the calendar event `calendar.event` corresponding to the configured holiday `hr.holidays.public.line`, the `partner_ids` field is not filled in (leave empty).