### PR TITLE
[FIX] allow batch actions on custom_hour_interval

### DIFF
--- a/hr_leave_custom_hour_interval/models/hr_leave.py
+++ b/hr_leave_custom_hour_interval/models/hr_leave.py
@@ -19,12 +19,12 @@ class HrLeave(models.Model):
     @api.depends("request_time_hour_from")
     def _compute_hour_from(self):
         for leave in self:
-            leave.request_hour_from = "%.2f" % self.request_time_hour_from
+            leave.request_hour_from = "%.2f" % leave.request_time_hour_from
 
     @api.depends("request_time_hour_to")
     def _compute_hour_to(self):
         for leave in self:
-            leave.request_hour_to = "%.2f" % self.request_time_hour_to
+            leave.request_hour_to = "%.2f" % leave.request_time_hour_to
 
     @api.depends("request_time_hour_from", "request_time_hour_to")
     def _compute_date_from_to(self):


### PR DESCRIPTION
As described on #103, when approving company-level leaves, the custom_hour_interval raises a `Expected singleton` error.

This PR fixes that by replacing the object from we're getting the `request_time_hour_from` to the individual leave rather the entire `self` object.