### PR TITLE
test hr_holidays_calendar_event_privacy separately

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,8 @@
 # Do NOT update manually; changes here will be overwritten by Copier
-_commit: v1.17.2
+_commit: v1.20
 _src_path: gh:oca/oca-addons-repo-template
 ci: GitHub
+convert_readme_fragments_to_markdown: false
 generate_requirements_txt: true
 github_check_license: true
 github_ci_extra_env: {}
@@ -14,9 +15,12 @@ odoo_test_flavor: Both
 odoo_version: 15.0
 org_name: Odoo Community Association (OCA)
 org_slug: OCA
-rebel_module_groups: []
-repo_description: 'TODO: add repo description.'
+rebel_module_groups:
+- hr_holidays_calendar_event_privacy
+repo_description: 'Modules extending the HR Holidays addon from Odoo. '
 repo_name: hr-holidays
 repo_slug: hr-holidays
 repo_website: https://github.com/OCA/hr-holidays
+use_pyproject_toml: false
+use_ruff: false
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,17 @@ jobs:
       matrix:
         include:
           - container: ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest
+            include: "hr_holidays_calendar_event_privacy"
             name: test with Odoo
           - container: ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest
+            include: "hr_holidays_calendar_event_privacy"
+            name: test with OCB
+            makepot: "true"
+          - container: ghcr.io/oca/oca-ci/py3.8-odoo15.0:latest
+            exclude: "hr_holidays_calendar_event_privacy"
+            name: test with Odoo
+          - container: ghcr.io/oca/oca-ci/py3.8-ocb15.0:latest
+            exclude: "hr_holidays_calendar_event_privacy"
             name: test with OCB
             makepot: "true"
     services:
@@ -49,6 +58,9 @@ jobs:
           POSTGRES_DB: odoo
         ports:
           - 5432:5432
+    env:
+      INCLUDE: "${{ matrix.include }}"
+      EXCLUDE: "${{ matrix.exclude }}"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 /.venv
 /.pytest_cache
+/.ruff_cache
 
 # C extensions
 *.so

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,8 @@ exclude: |
   ^docs/_templates/.*\.html$|
   # Don't bother non-technical authors with formatting issues in docs
   readme/.*\.(rst|md)$|
+  # Ignore build and dist directories in addons
+  /build/|/dist/|
   # You don't usually want a bot to modify your legal texts
   (LICENSE.*|COPYING.*)
 default_language_version:
@@ -35,7 +37,7 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
   - repo: https://github.com/oca/maintainer-tools
-    rev: 969238e47c07d0c40573acff81d170f63245d738
+    rev: 9a170331575a265c092ee6b24b845ec508e8ef75
     hooks:
       # update the NOT INSTALLABLE ADDONS section above
       - id: oca-update-pre-commit-excluded-addons
@@ -48,6 +50,7 @@ repos:
           - --org-name=OCA
           - --repo-name=hr-holidays
           - --if-source-changed
+          - --keep-source-digest
   - repo: https://github.com/OCA/odoo-pre-commit-hooks
     rev: v0.0.25
     hooks:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 # hr-holidays
 
-TODO: add repo description.
+Modules extending the HR Holidays addon from Odoo. 
 
 <!-- /!\ do not modify below this line -->
 


### PR DESCRIPTION
The tests on the 15.0 branch are broken because of a failing test in hr_holidays_calendar_event_privacy. This looks like a bad interaction with another module so I'm moving the testing of hr_holidays_calendar_event_privacy to a separate batch. 

Done as part of an update of the copier template