### PR TITLE
[16.0][FIX] hr_holidays_natural_period: Recalculate the duration value on creation

### DIFF
--- a/hr_holidays_natural_period/models/hr_leave.py
+++ b/hr_holidays_natural_period/models/hr_leave.py
@@ -1,7 +1,7 @@
-# Copyright 2020-2022 Tecnativa - Víctor Martínez
+# Copyright 2020-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import models
+from odoo import api, models
 
 
 class HrLeave(models.Model):
@@ -14,3 +14,13 @@ class HrLeave(models.Model):
         return super(HrLeave, instance)._get_number_of_days(
             date_from, date_to, employee_id
         )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """Only in UX an incorrect value is set, recalculate.
+        https://github.com/OCA/hr-holidays/issues/105."""
+        res = super().create(vals_list)
+        res.filtered(
+            lambda x: x.holiday_status_id.request_unit == "natural_day"
+        )._compute_number_of_days()
+        return res

--- a/hr_holidays_natural_period/models/hr_leave_type.py
+++ b/hr_holidays_natural_period/models/hr_leave_type.py
@@ -16,8 +16,8 @@ class HrLeaveType(models.Model):
         """We need to set request_unit as 'day' to avoid the calculations being done
         as hours.
         Related code:
-        hr_holidays/models/hr_leave_type.py#L313
-        hr_holidays/models/hr_leave_type.py#L367
+        hr_holidays/models/hr_leave_type.py#L326
+        hr_holidays/models/hr_leave_type.py#L389
         """
         old_request_unit_data = {}
         for item in self.filtered(lambda x: x.request_unit == "natural_day"):


### PR DESCRIPTION
Recalculate the duration value on creation

It is necessary to recalculate the duration value in the `create()` method when it is done by UX.

Fixes https://github.com/OCA/hr-holidays/issues/105

@Tecnativa 