### PR TITLE
[16.0][FIX] hr_holidays_public*: Use the context employee or the user's employee

### DIFF
--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -55,6 +55,13 @@ class HrLeave(models.Model):
 
     def _get_domain_from_get_unusual_days(self, date_from, date_to=None):
         domain = [("date", ">=", date_from)]
+        # Use the employee of the user or the one who has the context
+        employee_id = self.env.context.get("employee_id", False)
+        employee = (
+            self.env["hr.employee"].browse(employee_id)
+            if employee_id
+            else self.env.user.employee_id
+        )
         if date_to:
             domain.append(
                 (
@@ -63,7 +70,7 @@ class HrLeave(models.Model):
                     date_to,
                 )
             )
-        country_id = self.env.user.employee_id.address_id.country_id.id
+        country_id = employee.address_id.country_id.id
         if not country_id:
             country_id = self.env.company.country_id.id or False
         if country_id:
@@ -74,7 +81,7 @@ class HrLeave(models.Model):
                     ("year_id.country_id", "=", country_id),
                 ]
             )
-        state_id = self.env.user.employee_id.address_id.state_id.id
+        state_id = employee.address_id.state_id.id
         if not state_id:
             state_id = self.env.company.state_id.id or False
         if state_id:

--- a/hr_holidays_public/tests/test_holidays_public.py
+++ b/hr_holidays_public/tests/test_holidays_public.py
@@ -19,6 +19,7 @@ class TestHolidaysPublicBase(TransactionCase):
         cls.holiday_model_line = cls.env["hr.holidays.public.line"]
         cls.employee_model = cls.env["hr.employee"]
         cls.wizard_next_year = cls.env["public.holidays.next.year.wizard"]
+        cls.leave_model = cls.env["hr.leave"]
 
         # Remove possibly existing public holidays that would interfer.
         cls.holiday_model_line.search([]).unlink()
@@ -208,8 +209,7 @@ class TestHolidaysPublic(TestHolidaysPublicBase):
         self, expected, country_id=None, state_ids=False
     ):
         self.assertFalse(
-            self.env["hr.leave"]
-            .with_user(self.env.ref("base.user_demo").id)
+            self.leave_model.with_user(self.env.ref("base.user_demo").id)
             .get_unusual_days("2019-07-01", date_to="2019-07-31")
             .get("2019-07-30", False)
         )
@@ -223,10 +223,20 @@ class TestHolidaysPublic(TestHolidaysPublicBase):
             }
         )
         self.assertEqual(
-            self.env["hr.leave"]
-            .with_user(self.env.ref("base.user_demo").id)
-            .get_unusual_days("2019-07-01", date_to="2019-07-31")["2019-07-30"],
+            self.leave_model.with_user(
+                self.env.ref("base.user_demo").id
+            ).get_unusual_days("2019-07-01", date_to="2019-07-31")["2019-07-30"],
             expected,
+        )
+
+    def test_public_holidays_context(self):
+        self.env.ref("base.user_demo").employee_id.address_id.country_id = False
+        self.leave_model = self.leave_model.with_context(employee_id=self.employee.id)
+        self.assertPublicHolidayIsUnusualDay(
+            True,
+            country_id=self.env.ref(
+                "base.user_demo"
+            ).employee_id.address_id.country_id.id,
         )
 
     def test_get_unusual_days_return_public_holidays_same_country(self):

--- a/hr_holidays_public_city/models/hr_leave.py
+++ b/hr_holidays_public_city/models/hr_leave.py
@@ -10,8 +10,15 @@ class HrLeave(models.Model):
         domain = super()._get_domain_from_get_unusual_days(
             date_from=date_from, date_to=date_to
         )
+        # Use the employee of the user or the one who has the context
+        employee_id = self.env.context.get("employee_id", False)
+        employee = (
+            self.env["hr.employee"].browse(employee_id)
+            if employee_id
+            else self.env.user.employee_id
+        )
         # Add city domain
-        city_id = self.env.user.employee_id.address_id.city_id.id
+        city_id = employee.address_id.city_id.id
         if not city_id:
             city_id = self.env.company.partner_id.city_id.id or False
         if city_id:


### PR DESCRIPTION
FWP from 15.0: https://github.com/OCA/hr-holidays/pull/130

Locked by:
- [x] `web`: https://github.com/odoo/odoo/pull/172380

Use the context employee or the user's employee

Use case:
- Go to Employees to an employee with a different address (country) than our own and with specific public holidays for that country.
- Go to the Time-off smart-buttons
- We will have to see there the public holidays according to the employee's address

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT49839