### PR TITLE
[17.0][FIX] hr_holidays_public*: Use the context employee or the user's employee

### DIFF
--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -52,6 +52,13 @@ class HrLeave(models.Model):
 
     def _get_domain_from_get_unusual_days(self, date_from, date_to=None):
         domain = [("date", ">=", date_from)]
+        # Use the employee of the user or the one who has the context
+        employee_id = self.env.context.get("employee_id", False)
+        employee = (
+            self.env["hr.employee"].browse(employee_id)
+            if employee_id
+            else self.env.user.employee_id
+        )
         if date_to:
             domain.append(
                 (
@@ -60,7 +67,7 @@ class HrLeave(models.Model):
                     date_to,
                 )
             )
-        country_id = self.env.user.employee_id.address_id.country_id.id
+        country_id = employee.address_id.country_id.id
         if not country_id:
             country_id = self.env.company.country_id.id or False
         if country_id:
@@ -71,7 +78,7 @@ class HrLeave(models.Model):
                     ("year_id.country_id", "=", country_id),
                 ]
             )
-        state_id = self.env.user.employee_id.address_id.state_id.id
+        state_id = employee.address_id.state_id.id
         if not state_id:
             state_id = self.env.company.state_id.id or False
         if state_id:

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -185,7 +185,6 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
                 "employee_id": self.employee_2.id,
             }
         )
-        leave_request.action_validate()
 
         self.assertEqual(leave_request.number_of_days, 2)
         self.assertEqual(leave_request.number_of_hours_display, 16)

--- a/hr_holidays_public_city/models/hr_leave.py
+++ b/hr_holidays_public_city/models/hr_leave.py
@@ -10,8 +10,15 @@ class HrLeave(models.Model):
         domain = super()._get_domain_from_get_unusual_days(
             date_from=date_from, date_to=date_to
         )
+        # Use the employee of the user or the one who has the context
+        employee_id = self.env.context.get("employee_id", False)
+        employee = (
+            self.env["hr.employee"].browse(employee_id)
+            if employee_id
+            else self.env.user.employee_id
+        )
         # Add city domain
-        city_id = self.env.user.employee_id.address_id.city_id.id
+        city_id = employee.address_id.city_id.id
         if not city_id:
             city_id = self.env.company.partner_id.city_id.id or False
         if city_id:


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/hr-holidays/pull/132

Use the context employee or the user's employee

Use case:
- Go to Employees to an employee with a different address (country) than our own and with specific public holidays for that country.
- Go to the Time-off smart-buttons
- We will have to see there the public holidays according to the employee's address

Please @pedrobaeza and @carolinafernandez-tecnativa can you review it?

@Tecnativa TT49839