### PR TITLE
[15.0][IMP] hr_holidays_public: include public holidays in employee's _get_unusual_days

### DIFF
--- a/hr_holidays_public/models/__init__.py
+++ b/hr_holidays_public/models/__init__.py
@@ -4,3 +4,4 @@ from . import hr_leave
 from . import hr_leave_type
 from . import hr_holidays_public
 from . import resource_calendar
+from . import hr_employee

--- a/hr_holidays_public/models/hr_employee.py
+++ b/hr_holidays_public/models/hr_employee.py
@@ -1,0 +1,17 @@
+from odoo import fields, models
+
+
+class HREmployee(models.Model):
+    _inherit = "hr.employee"
+
+    def _get_unusual_days(self, date_from, date_to=None):
+        res = super()._get_unusual_days(date_from, date_to=date_to)
+        if not self:
+            return res
+        domain = self.env["hr.leave"]._get_domain_from_get_unusual_days(
+            date_from=date_from, date_to=date_to
+        )
+        public_holidays = self.env["hr.holidays.public.line"].search(domain)
+        for public_holiday in public_holidays:
+            res[fields.Date.to_string(public_holiday.date)] = True
+        return res

--- a/hr_holidays_public/tests/test_holidays_public.py
+++ b/hr_holidays_public/tests/test_holidays_public.py
@@ -376,3 +376,10 @@ class TestHolidaysPublic(TestHolidaysPublicBase):
         self.assertEqual(
             intervals_sl[resource_sl.id]._items, intervals_sk_sl[resource_sl.id]._items
         )
+
+    def _test_get_unusual_days(self):
+        # Test for _get_unusual_days
+        unusual_days = self.employee._get_unusual_days("1994-11-14", "1994-11-14")
+        self.assertIn("1994-10-14", unusual_days)
+        self.assertTrue(unusual_days["1994-10-14"])
+        self.assertNotIn("1994-10-15", unusual_days)


### PR DESCRIPTION
This is useful in the time off overview calendar, from:
![image](https://github.com/user-attachments/assets/da6e3846-49d9-463c-be16-99a9d79146d9)

to:
![image](https://github.com/user-attachments/assets/eee519c0-54b4-4621-9b3d-d889f66dc52d)


cc @forgeflow
