### PR TITLE
[16.0][FIX] hr_holidays_summary_email: change message if empty summary

### DIFF
--- a/hr_holidays_summary_email/data/mail_template_data.xml
+++ b/hr_holidays_summary_email/data/mail_template_data.xml
@@ -12,47 +12,53 @@
                 <div style="margin: 0px; padding: 0px;">
                     <p>Dear <t t-out="object.name" />,</p>
                     <br />
-                    <p>This is today's leave summary:</p>
-                    <br />
-                    <table
-                    style="border-spacing: 0; border-collapse: collapse; width: 100%; text-align: center;"
-                >
-                        <tr>
-                            <th
-                            style="padding: 5px; border: 1px solid black;"
-                        >Employee</th>
-                            <th
-                            style="padding: 5px; border: 1px solid black;"
-                        >Time Off</th>
-                            <th style="padding: 5px; border: 1px solid black;">From</th>
-                            <th style="padding: 5px; border: 1px solid black;">To</th>
-                        </tr>
-                        <t t-set="timeoffs" t-value="ctx.get('time_offs', [])" />
-                        <t t-foreach="timeoffs" t-as="data">
-                            <t
-                            t-set="d_from"
-                            t-value="data.format_hr_leave_summary_date()"
-                        />
-                            <t
-                            t-set="d_to"
-                            t-value="data.format_hr_leave_summary_date(False)"
-                        />
+                    <t t-set="timeoffs" t-value="ctx.get('time_offs', [])" />
+                    <t t-if="timeoffs">
+                        <p>This is today's leave summary:</p>
+                        <br />
+                        <table
+                        style="border-spacing: 0; border-collapse: collapse; width: 100%; text-align: center;"
+                    >
                             <tr>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="data.employee_id.name"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="data.name or ''"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="d_from"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="d_to"
-                                /></td>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >Employee</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >Time Off</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >From</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >To</th>
                             </tr>
-                        </t>
-                    </table>
+                            <t t-foreach="timeoffs" t-as="data">
+                                <t
+                                t-set="d_from"
+                                t-value="data.format_hr_leave_summary_date()"
+                            />
+                                <t
+                                t-set="d_to"
+                                t-value="data.format_hr_leave_summary_date(False)"
+                            />
+                                <tr>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="data.employee_id.name" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="data.name or ''" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="d_from" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="d_to" /></td>
+                                </tr>
+                            </t>
+                        </table></t>
+                    <t t-else=""><p>No leaves for today.</p></t>
                 </div>
             </field>
             <field name="lang">{{object.lang}}</field>
@@ -70,47 +76,53 @@
                 <div style="margin: 0px; padding: 0px;">
                     <p>Dear <t t-out="object.name" />,</p>
                     <br />
-                    <p>This is the leaves summary for this week:</p>
-                    <br />
-                    <table
-                    style="border-spacing: 0; border-collapse: collapse; width: 100%; text-align: center;"
-                >
-                        <tr>
-                            <th
-                            style="padding: 5px; border: 1px solid black;"
-                        >Employee</th>
-                            <th
-                            style="padding: 5px; border: 1px solid black;"
-                        >Time Off</th>
-                            <th style="padding: 5px; border: 1px solid black;">From</th>
-                            <th style="padding: 5px; border: 1px solid black;">To</th>
-                        </tr>
-                        <t t-set="timeoffs" t-value="ctx.get('time_offs', [])" />
-                        <t t-foreach="timeoffs" t-as="data">
-                            <t
-                            t-set="d_from"
-                            t-value="data.format_hr_leave_summary_date()"
-                        />
-                            <t
-                            t-set="d_to"
-                            t-value="data.format_hr_leave_summary_date(False)"
-                        />
+                    <t t-set="timeoffs" t-value="ctx.get('time_offs', [])" />
+                    <t t-if="timeoffs">
+                        <p>This is the leaves summary for this week:</p>
+                        <br />
+                        <table
+                        style="border-spacing: 0; border-collapse: collapse; width: 100%; text-align: center;"
+                    >
                             <tr>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="data.employee_id.name"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="data.name or ''"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="d_from"
-                                /></td>
-                                <td style="padding: 5px; border: 1px solid black;"><t
-                                    t-out="d_to"
-                                /></td>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >Employee</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >Time Off</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >From</th>
+                                <th
+                                style="padding: 5px; border: 1px solid black;"
+                            >To</th>
                             </tr>
-                        </t>
-                    </table>
+                            <t t-foreach="timeoffs" t-as="data">
+                                <t
+                                t-set="d_from"
+                                t-value="data.format_hr_leave_summary_date()"
+                            />
+                                <t
+                                t-set="d_to"
+                                t-value="data.format_hr_leave_summary_date(False)"
+                            />
+                                <tr>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="data.employee_id.name" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="data.name or ''" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="d_from" /></td>
+                                    <td
+                                    style="padding: 5px; border: 1px solid black;"
+                                ><t t-out="d_to" /></td>
+                                </tr>
+                            </t>
+                        </table></t>
+                    <t t-else=""><p>No leaves for this week.</p></t>
                 </div>
             </field>
             <field name="lang">{{object.lang}}</field>

--- a/hr_holidays_summary_email/models/hr_leave.py
+++ b/hr_holidays_summary_email/models/hr_leave.py
@@ -71,12 +71,12 @@ class HrLeave(models.Model):
         if str(fields.Date.today().weekday()) != company.hr_holidays_summary_weekly_dow:
             return
         domain = self._get_hr_leave_summary_weekly_domain(company.id)
-        today_time_offs = self.env["hr.leave"].sudo().search(domain)
+        weekly_time_offs = self.env["hr.leave"].sudo().search(domain)
         template = self._get_hr_leave_summary_mail_template("weekly")
         if not template:
             return
         for employee in employees_to_notify:
-            template.with_context(time_offs=today_time_offs).send_mail(
+            template.with_context(time_offs=weekly_time_offs).send_mail(
                 employee.id, force_send=False
             )
         employees_to_notify.write({"last_hr_leave_summary_sent": fields.Date.today()})


### PR DESCRIPTION
Avoid having a mail with:

![Selection_4019](https://github.com/user-attachments/assets/d6e1259e-a956-4151-bdce-be8c98bb39da)
