### PR TITLE
[16.0][FIX][hr_holidays_natural_period] date min/max start/end

### DIFF
--- a/hr_holidays_natural_period/models/hr_leave.py
+++ b/hr_holidays_natural_period/models/hr_leave.py
@@ -1,6 +1,8 @@
 # Copyright 2020-2024 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from datetime import datetime
+
 from odoo import api, models
 
 
@@ -8,9 +10,12 @@ class HrLeave(models.Model):
     _inherit = "hr.leave"
 
     def _get_number_of_days(self, date_from, date_to, employee_id):
-        instance = self.with_context(
-            natural_period=bool(self.holiday_status_id.request_unit == "natural_day")
-        )
+        instance = self
+        if self.holiday_status_id.request_unit:
+            instance = self.with_context(natural_period=True)
+            date_from = datetime.combine(date_from, datetime.min.time())
+            date_to = datetime.combine(date_to, datetime.max.time())
+
         return super(HrLeave, instance)._get_number_of_days(
             date_from, date_to, employee_id
         )


### PR DESCRIPTION
If the user's configuration is in a timezone and the browser the number of days off is calculated incorrectly showing fractions.

![image](https://github.com/user-attachments/assets/ec59c139-8619-4aea-975c-6aefd999dab2)