### PR TITLE
[17.0][FIX] hr_holidays_public: show employee's public holidays in dashboard

### DIFF
--- a/hr_holidays_public/models/__init__.py
+++ b/hr_holidays_public/models/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import hr_employee
 from . import hr_leave
 from . import hr_leave_type
 from . import hr_holidays_public

--- a/hr_holidays_public/models/hr_employee.py
+++ b/hr_holidays_public/models/hr_employee.py
@@ -1,0 +1,43 @@
+# Copyright 2024 Tecnativa - David Vidal
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import datetime
+
+from odoo import api, models
+
+
+class HrEmployee(models.Model):
+    _inherit = "hr.employee"
+
+    def _get_public_holiday_lines(self, date_start, date_end):
+        """Just get the employees holidays"""
+        domain = self.env["hr.leave"]._get_domain_from_get_unusual_days(
+            date_from=date_start, date_to=date_end
+        )
+        return self.env["hr.holidays.public.line"].search(domain)
+
+    @api.model
+    def get_public_holidays_data(self, date_start, date_end):
+        # Include public holidays in the calendar summary
+        res = super().get_public_holidays_data(date_start, date_end)
+        self = self._get_contextual_employee()
+        public_holidays = self._get_public_holiday_lines(date_start, date_end).sorted(
+            "date"
+        )
+        res += list(
+            map(
+                lambda bh: {
+                    "id": -bh.id,
+                    "colorIndex": 0,
+                    "end": (datetime.combine(bh.date, datetime.max.time())).isoformat(),
+                    "endType": "datetime",
+                    "isAllDay": True,
+                    "start": (
+                        datetime.combine(bh.date, datetime.min.time())
+                    ).isoformat(),
+                    "startType": "datetime",
+                    "title": bh.name,
+                },
+                public_holidays,
+            )
+        )
+        return sorted(res, key=lambda x: x["start"])


### PR DESCRIPTION
This change hooks into the core public holidays method that returns the employee's available holidays for a period of time and displays them in the Time Off dashboard calendar.

Both types of public holidays are compatible and will show up in order.

![image](https://github.com/user-attachments/assets/61c4bb0e-6e48-47cc-a8b5-f7d65c42d7a8)


cc @Tecnativa TT52276

please review @pedrobaeza @victoralmau 