### PR TITLE
[16.0][FIX]hr_holidays_public: mute distracting warnings

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -89,7 +89,11 @@ class HrHolidaysPublic(models.Model):
         :param employee_id: ID of the employee
         :return: recordset of hr.holidays.public.line
         """
-        partner = self._get_partner_deprecated_employee(partner_id, employee_id)
+        partner = (
+            self.env["hr.employee"].browse(employee_id).address_id
+            if employee_id and not partner_id
+            else self._get_partner_deprecated_employee(partner_id, employee_id)
+        )
         if not start_dt and not end_dt:
             start_dt = datetime.date(year, 1, 1)
             end_dt = datetime.date(year, 12, 31)


### PR DESCRIPTION
calling the method `_get_partner_deprecated_employee` results in the logging of warnings
> odoo.addons.hr_holidays_public.models.hr_holidays_public: Use of employee_id for hr.public.holidays is deprecated. Please use partner_id instead. 

The objective of this PR is to limit as much as possible these warnings, as they can be quite distracting for more serious issues