### PR TITLE
[16.0][FIX] hr_holidays_natural_period: Define the correct number of days in some use cases.

### DIFF
--- a/hr_holidays_natural_period/models/resource_calendar.py
+++ b/hr_holidays_natural_period/models/resource_calendar.py
@@ -21,6 +21,10 @@ class ResourceCalendar(models.Model):
         return False
 
     def _natural_period_intervals_batch(self, start_dt, end_dt, intervals, resources):
+        # Re-define start_dt and end_dt to ensure that we always iterate through the
+        # last day.
+        start_dt = datetime.combine(start_dt.date(), time.min)
+        end_dt = datetime.combine(end_dt.date(), time.max)
         for resource in resources or []:
             interval_resource = intervals[resource.id]
             tz = timezone(resource.tz)

--- a/hr_holidays_natural_period/tests/test_hr_leave.py
+++ b/hr_holidays_natural_period/tests/test_hr_leave.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Tecnativa - Víctor Martínez
+# Copyright 2020-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from freezegun import freeze_time
 
@@ -77,7 +77,7 @@ class TestHrLeave(common.TransactionCase):
         return leave_form.save()
 
     @users("test-user")
-    def test_hr_leave_natural_day(self):
+    def test_hr_leave_natural_day_01(self):
         leave_allocation = self._create_leave_allocation(self.leave_type, 5)
         leave_allocation.action_confirm()
         leave_allocation.sudo().action_validate()
@@ -91,6 +91,34 @@ class TestHrLeave(common.TransactionCase):
         leave = self._create_hr_leave(self.leave_type, "2023-01-02", "2023-01-05")
         self.assertEqual(leave.number_of_days, 4.0)
         self.assertEqual(leave.number_of_days_display, 4.0)
+
+    @users("test-user")
+    def test_hr_leave_natural_day_02(self):
+        attendances = [(0, 16, 21), (1, 9, 14), (2, 9, 14), (3, 9, 14), (4, 9, 14)]
+        r_sudo = self.env["resource.calendar"].sudo()
+        calendar = r_sudo.create(
+            {
+                "name": "Test calendar",
+                "tz": "Europe/Brussels",
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": index,
+                            "dayofweek": str(att[0]),
+                            "hour_from": att[1],
+                            "hour_to": att[2],
+                        },
+                    )
+                    for index, att in enumerate(attendances)
+                ],
+            }
+        )
+        self.employee.resource_calendar_id = calendar
+        leave = self._create_hr_leave(self.leave_type, "2022-12-31", "2023-01-08")
+        self.assertEqual(leave.number_of_days, 9.0)
+        self.assertEqual(leave.number_of_days_display, 9.0)
 
     @users("test-user")
     def test_hr_leave_day(self):


### PR DESCRIPTION
Define the correct number of days in some use cases.

Example use case:
- Calendar Monday 16:00-21:00
- Calendar Tuesday-Friday: 09:00-14:00
- Absence from Monday to Sunday in natural day
- Number of days: 7

Please @pedrobaeza can you review it?

@Tecnativa TT55243