### PR TITLE
[17.0][FIX] hr_holidays_natural_period: Define the correct number of days in some use cases

### DIFF
--- a/hr_holidays_natural_period/models/resource_calendar.py
+++ b/hr_holidays_natural_period/models/resource_calendar.py
@@ -56,6 +56,10 @@ class ResourceCalendar(models.Model):
         return False
 
     def _natural_period_intervals_batch(self, start_dt, end_dt, intervals, resources):
+        # Re-define start_dt and end_dt to ensure that we always iterate through the
+        # last day.
+        start_dt = datetime.combine(start_dt.date(), time.min)
+        end_dt = datetime.combine(end_dt.date(), time.max)
         for resource in resources or []:
             interval_resource = intervals[resource.id]
             tz = timezone(resource.tz)

--- a/hr_holidays_natural_period/tests/test_hr_leave.py
+++ b/hr_holidays_natural_period/tests/test_hr_leave.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2023 Tecnativa - Víctor Martínez
+# Copyright 2020-2025 Tecnativa - Víctor Martínez
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 from freezegun import freeze_time
 
@@ -69,7 +69,7 @@ class TestHrLeave(BaseCommon):
         return leave_form.save()
 
     @users("test-user")
-    def test_hr_leave_natural_day(self):
+    def test_hr_leave_natural_day_01(self):
         leave_allocation = self._create_leave_allocation(self.leave_type, 5)
         leave_allocation.sudo().action_validate()
         res_leave_type = (
@@ -86,6 +86,34 @@ class TestHrLeave(BaseCommon):
         leave = self._create_hr_leave(self.leave_type, "2023-01-02", "2023-01-05")
         self.assertEqual(leave.number_of_days, 4.0)
         self.assertEqual(leave.number_of_days_display, 4.0)
+
+    @users("test-user")
+    def test_hr_leave_natural_day_02(self):
+        attendances = [(0, 16, 21), (1, 9, 14), (2, 9, 14), (3, 9, 14), (4, 9, 14)]
+        r_sudo = self.env["resource.calendar"].sudo()
+        calendar = r_sudo.create(
+            {
+                "name": "Test calendar",
+                "tz": "Europe/Brussels",
+                "attendance_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": index,
+                            "dayofweek": str(att[0]),
+                            "hour_from": att[1],
+                            "hour_to": att[2],
+                        },
+                    )
+                    for index, att in enumerate(attendances)
+                ],
+            }
+        )
+        self.employee.resource_calendar_id = calendar
+        leave = self._create_hr_leave(self.leave_type, "2022-12-31", "2023-01-08")
+        self.assertEqual(leave.number_of_days, 9.0)
+        self.assertEqual(leave.number_of_days_display, 9.0)
 
     @users("test-user")
     def test_hr_leave_day(self):


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/hr-holidays/pull/167

Define the correct number of days in some use cases.

Example use case:
- Calendar Monday 16:00-21:00
- Calendar Tuesday-Friday: 09:00-14:00
- Absence from Monday to Sunday in natural day
- Number of days: 7

This is due to the rrule we are using to generate the missing intervals for the non working days to simulate the natural period. Previously, we use the starting and ending time, resulting that the daily rrule was omitting the initial or ending day, as the theoretical hour is after the ending datetime. For the example above, the rrule will generate the entries from Monday at 16:00, so when the time for the Sunday rule comes, as Sun 16:00 is bigger than Sun 14:00, which was the ending datetime, no iteration is done for Sunday.

The solution is to put the rrule with the min time for the starting limit, and the maximum for the ending one.

It has been checked that there's no problem with timezones due to this patch.

Please @pedrobaeza can you review it?

@Tecnativa TT55243