### PR TITLE
[17.0][FIX] hr_holidays_natural_period: _get_duration handle modified request_unit

### DIFF
--- a/hr_holidays_natural_period/README.rst
+++ b/hr_holidays_natural_period/README.rst
@@ -81,6 +81,10 @@ Contributors
 
      - Antoni Marroig <amarroig@apsl.net>
 
+- Grupo Isonor <https://www.grupoisonor.es>
+
+     - Alexandre D. Díaz
+
 Maintainers
 -----------
 

--- a/hr_holidays_natural_period/models/hr_employee.py
+++ b/hr_holidays_natural_period/models/hr_employee.py
@@ -1,4 +1,5 @@
 # Copyright 2024 APSL-Nagarro - Antoni Marroig Campomar
+# Copyright 2025 Grupo Isonor - Alexandre D. Díaz
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
@@ -11,12 +12,13 @@ class HrEmployee(models.Model):
         """We need to set request_unit as 'day' to avoid the calculations being done
         as hours.
         """
-        old_request_unit_data = {}
-        for item in leave_types.filtered(lambda x: x.request_unit == "natural_day"):
-            old_request_unit_data[item.id] = item.request_unit
-            item.sudo().request_unit = "day"
-        res = super()._get_consumed_leaves(leave_types, target_date, ignore_future)
+        mod_leave_type_ids = self.env["hr.leave.type"]
         for item in leave_types:
-            if item.id in old_request_unit_data:
-                item.sudo().request_unit = old_request_unit_data[item.id]
+            if item.request_unit == "natural_day":
+                item.sudo().request_unit = "day"
+                mod_leave_type_ids |= item
+        self = self.with_context(mod_holidays_status_ids=mod_leave_type_ids.ids)
+        res = super()._get_consumed_leaves(leave_types, target_date, ignore_future)
+        for item in mod_leave_type_ids:
+            item.sudo().request_unit = "natural_day"
         return res

--- a/hr_holidays_natural_period/models/hr_leave.py
+++ b/hr_holidays_natural_period/models/hr_leave.py
@@ -1,5 +1,6 @@
 # Copyright 2020-2024 Tecnativa - Víctor Martínez
 # Copyright 2024 Tecnativa - Carlos Lopez
+# Copyright 2025 Grupo Isonor - Alexandre D. Díaz
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -11,7 +12,9 @@ class HrLeave(models.Model):
     def _get_duration(self, check_leave_type=True, resource_calendar=None):
         # We need to set request_unit as 'day'
         # to avoid the calculations being done as hours.
-        is_request_unit_natural_day = (
+        mod_holidays_status_ids = self.env.context.get("mod_holidays_status_ids", [])
+        is_mod_leave_type = self.holiday_status_id.id in mod_holidays_status_ids
+        is_request_unit_natural_day = is_mod_leave_type or (
             self.holiday_status_id.request_unit == "natural_day"
         )
         instance = self.with_context(natural_period=is_request_unit_natural_day)

--- a/hr_holidays_natural_period/readme/CONTRIBUTORS.md
+++ b/hr_holidays_natural_period/readme/CONTRIBUTORS.md
@@ -7,3 +7,7 @@
 - APSL-Nagarro \<<https://www.apsl.tech>\>
 
   > - Antoni Marroig \<<amarroig@apsl.net>\>
+
+- Grupo Isonor \<<https://www.grupoisonor.es>\>
+
+  > - Alexandre D. Díaz

--- a/hr_holidays_natural_period/static/description/index.html
+++ b/hr_holidays_natural_period/static/description/index.html
@@ -434,6 +434,13 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </ul>
 </blockquote>
 </li>
+<li><p class="first">Grupo Isonor &lt;<a class="reference external" href="https://www.grupoisonor.es">https://www.grupoisonor.es</a>&gt;</p>
+<blockquote>
+<ul class="simple">
+<li>Alexandre D. Díaz</li>
+</ul>
+</blockquote>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Solves a problem with the calculation of days. The problem comes from the “hack” that is used to calculate the days as “day” type (since the Odoo method is ungovernable). With this fix, a history is kept in the context to know if a record is really of type “day” or “natural_day”.

![time_off](https://github.com/user-attachments/assets/e25a0945-d479-4d89-9e51-16baa4cab80c)

Steps to reproduce (with demo data):

1. Go to "Time Off > Configuration > Time Off Types" application
2. Edit "Paid Time Off" and change "Take Time Off in" to "Natural Day"
3. Go to calendar and allocate 1 week (7 natural days)
4. Check the "Paid Time Off" counter... it shows 15 instead of 13
