### PR TITLE
[16.0][FIX]hr_holidays_public: handle incompatibility with `hr_work_entry_holidays` by propagating the context upwards

### DIFF
--- a/hr_holidays_public/README.rst
+++ b/hr_holidays_public/README.rst
@@ -145,6 +145,10 @@ Contributors
 
   * Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pesol.es>
 
+* `Pytech SRL <https://www.pytech.it>`__:
+
+  * Sebastiano Picchi <sebastiano.picchi@pytech.it>
+
 Maintainers
 ~~~~~~~~~~~
 

--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -3,6 +3,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import api, fields, models
+from odoo.tools.misc import frozendict
 
 
 class HrLeave(models.Model):
@@ -25,15 +26,22 @@ class HrLeave(models.Model):
         return True
 
     def _get_number_of_days(self, date_from, date_to, employee_id):
+        # propagate context upwards
+        # solves compatibility issue w/ hr_work_entry_holidays
         if self.holiday_status_id.exclude_public_holidays or not self.holiday_status_id:
-            instance = self.with_context(
-                employee_id=employee_id, exclude_public_holidays=True
+            new_context = frozendict(
+                self.env.context, employee_id=employee_id, exclude_public_holidays=True
             )
         else:
-            instance = self
-        return super(HrLeave, instance)._get_number_of_days(
-            date_from, date_to, employee_id
-        )
+            new_context = frozendict(
+                {
+                    k: v
+                    for k, v in self.env.context.items()
+                    if k not in ["employee_id", "exclude_public_holidays"]
+                }
+            )
+        self.env.context = new_context
+        return super(HrLeave, self)._get_number_of_days(date_from, date_to, employee_id)
 
     @api.depends("number_of_days")
     def _compute_number_of_hours_display(self):

--- a/hr_holidays_public/readme/CONTRIBUTORS.rst
+++ b/hr_holidays_public/readme/CONTRIBUTORS.rst
@@ -25,3 +25,7 @@
 * `Pesol <https://www.pesol.es>`__:
 
   * Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pesol.es>
+
+* `Pytech SRL <https://www.pytech.it>`__:
+
+  * Sebastiano Picchi <sebastiano.picchi@pytech.it>

--- a/hr_holidays_public/static/description/index.html
+++ b/hr_holidays_public/static/description/index.html
@@ -488,6 +488,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Pedro Evaristo Gonzalez Sanchez &lt;<a class="reference external" href="mailto:pedro.gonzalez&#64;pesol.es">pedro.gonzalez&#64;pesol.es</a>&gt;</li>
 </ul>
 </li>
+<li><a class="reference external" href="https://www.pytech.it">Pytech SRL</a>:<ul>
+<li>Sebastiano Picchi &lt;<a class="reference external" href="mailto:sebastiano.picchi&#64;pytech.it">sebastiano.picchi&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
The method `_get_number_of_days` introduced in `hr_work_entry_holidays`, is not being passed `exclude_public_holidays` in the context.
With this PR we propagate it in the calling methods too.