### PR TITLE
[17.0][IMP] hr_holidays_public: improve way to get public holidays

### DIFF
--- a/hr_holidays_public/README.rst
+++ b/hr_holidays_public/README.rst
@@ -47,7 +47,7 @@ Configuration
 Go to *Time Off -> Configuration -> Time Off Types* and open a Leave
 Type
 
-- Check "Exclude Public Holidays" to exclude public holidays.
+-  Check "Exclude Public Holidays" to exclude public holidays.
 
 Usage
 =====
@@ -123,37 +123,38 @@ Authors
 Contributors
 ------------
 
-- Michael Telahun Makonnen <mmakonnen@gmail.com>
-- Fekete Mihai <feketemihai@gmail.com>
-- Nikolina Todorova <nikolina.todorova@initos.com>
-- Alexis de Lattre <alexis.delattre@akretion.com>
-- Salton Massally (iDT Labs) <smassally@idtlabs.sl>
-- Ivan Yelizariev <yelizariev@it-projects.info>
-- Bassirou Ndaw <b.ndaw@ergobit.org>
-- Dhara Solanki <dhara.solanki@initos.com>
-- `Tecnativa <https://www.tecnativa.com>`__:
+-  Michael Telahun Makonnen <mmakonnen@gmail.com>
+-  Fekete Mihai <feketemihai@gmail.com>
+-  Nikolina Todorova <nikolina.todorova@initos.com>
+-  Alexis de Lattre <alexis.delattre@akretion.com>
+-  Salton Massally (iDT Labs) <smassally@idtlabs.sl>
+-  Ivan Yelizariev <yelizariev@it-projects.info>
+-  Bassirou Ndaw <b.ndaw@ergobit.org>
+-  Dhara Solanki <dhara.solanki@initos.com>
+-  `Tecnativa <https://www.tecnativa.com>`__:
 
-  - Pedro M. Baeza
+   -  Pedro M. Baeza
 
-- `CorporateHub <https://corporatehub.eu/>`__
+-  `CorporateHub <https://corporatehub.eu/>`__
 
-  - Alexey Pelykh <alexey.pelykh@corphub.eu>
+   -  Alexey Pelykh <alexey.pelykh@corphub.eu>
 
-- `Camptocamp <https://www.camptocamp.com>`__:
+-  `Camptocamp <https://www.camptocamp.com>`__:
 
-  - Damien Crier <damien.crier@camptocamp.com>
+   -  Damien Crier <damien.crier@camptocamp.com>
+   -  Italo Lopes <italo.lopes@camptocamp.com>
 
-- `Druidoo <https://www.druidoo.io>`__:
+-  `Druidoo <https://www.druidoo.io>`__:
 
-  - Iván Todorovich <ivan.todorovich@gmail.com>
+   -  Iván Todorovich <ivan.todorovich@gmail.com>
 
-- `Pesol <https://www.pesol.es>`__:
+-  `Pesol <https://www.pesol.es>`__:
 
-  - Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pesol.es>
+   -  Pedro Evaristo Gonzalez Sanchez <pedro.gonzalez@pesol.es>
 
-- `Trobz <https://trobz.com>`__:
+-  `Trobz <https://trobz.com>`__:
 
-  - Thao Le <thaolt@trobz.com>
+   -  Thao Le <thaolt@trobz.com>
 
 Other credits
 -------------

--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -45,6 +45,11 @@ class ResourceCalendar(models.Model):
             lunch=lunch,
         )
         if self.env.context.get("exclude_public_holidays") and resources:
+            # We need to pass the employee_id to the context to be able to filter
+            # the public holidays correctly
+            employee_ids = resources.mapped("employee_id")
+            if len(employee_ids) == 1:
+                self = self.with_context(employee_id=employee_ids.id)
             return self._attendance_intervals_batch_exclude_public_holidays(
                 start_dt, end_dt, res, resources, tz
             )

--- a/hr_holidays_public/readme/CONTRIBUTORS.md
+++ b/hr_holidays_public/readme/CONTRIBUTORS.md
@@ -12,9 +12,10 @@
   - Alexey Pelykh \<<alexey.pelykh@corphub.eu>\>
 - [Camptocamp](https://www.camptocamp.com):
   - Damien Crier \<<damien.crier@camptocamp.com>\>
+  - Italo Lopes \<<italo.lopes@camptocamp.com>\>
 - [Druidoo](https://www.druidoo.io):
   - Iván Todorovich \<<ivan.todorovich@gmail.com>\>
 - [Pesol](https://www.pesol.es):
   - Pedro Evaristo Gonzalez Sanchez \<<pedro.gonzalez@pesol.es>\>
-- [Trobz](https://trobz.com):  
+- [Trobz](https://trobz.com):
   - Thao Le \<<thaolt@trobz.com>\>

--- a/hr_holidays_public/static/description/index.html
+++ b/hr_holidays_public/static/description/index.html
@@ -485,6 +485,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 </li>
 <li><a class="reference external" href="https://www.camptocamp.com">Camptocamp</a>:<ul>
 <li>Damien Crier &lt;<a class="reference external" href="mailto:damien.crier&#64;camptocamp.com">damien.crier&#64;camptocamp.com</a>&gt;</li>
+<li>Italo Lopes &lt;<a class="reference external" href="mailto:italo.lopes&#64;camptocamp.com">italo.lopes&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </li>
 <li><a class="reference external" href="https://www.druidoo.io">Druidoo</a>:<ul>


### PR DESCRIPTION
With this module we can create public holidays : 
* global, for any country
* by country
* by region/state

If we don't have an employee when calling `get_holidays_list`, we don't have the filter by states applied correctly.
This PR will just pass the ``resource.resource::employee_id`` in the context.