### PR TITLE
[17.0][FIX] hr_holidays_public: calendar.get_work_hours_count

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -2,6 +2,7 @@
 # Copyright 2018 Brainbean Apps
 # Copyright 2020 InitOS Gmbh
 # Copyright 2021 Tecnativa - Víctor Martínez
+# Copyright 2024 Pierre Verkest
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import models
@@ -44,6 +45,8 @@ class ResourceCalendar(models.Model):
             tz=tz,
             lunch=lunch,
         )
+        if resources is None:
+            resources = [self.env["resource.resource"]]
         if self.env.context.get("exclude_public_holidays") and resources:
             return self._attendance_intervals_batch_exclude_public_holidays(
                 start_dt, end_dt, res, resources, tz

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -2,7 +2,9 @@
 # Copyright 2017-2018 Tecnativa - Pedro M. Baeza
 # Copyright 2018 Brainbean Apps
 # Copyright 2020 InitOS Gmbh
+# Copyright 2024 Pierre Verkest
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from datetime import datetime
 
 from odoo.tests.common import TransactionCase
 
@@ -188,3 +190,27 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
 
         self.assertEqual(leave_request.number_of_days, 2)
         self.assertEqual(leave_request.number_of_hours_display, 16)
+
+    def test_compute_week_hours_without_public_holidays(self):
+        self.assertEqual(
+            self.calendar.with_context(
+                employee_id=self.employee_1.id, exclude_public_holidays=True
+            ).get_work_hours_count(
+                datetime.combine(datetime(1946, 12, 16), datetime.min.time()),
+                datetime.combine(datetime(1946, 12, 22), datetime.max.time()),
+                compute_leaves=False,
+            ),
+            40,
+        )
+
+    def test_compute_week_hours_with_public_holidays(self):
+        self.assertEqual(
+            self.calendar.with_context(
+                employee_id=self.employee_1.id, exclude_public_holidays=True
+            ).get_work_hours_count(
+                datetime.combine(datetime(1946, 12, 23), datetime.min.time()),
+                datetime.combine(datetime(1946, 12, 29), datetime.max.time()),
+                compute_leaves=False,
+            ),
+            32,
+        )


### PR DESCRIPTION
Allow to call get_work_hours_count on resource.calendar taking care of public holidays.


This is a forward port of this PR https://github.com/OCA/hr-holidays/pull/142


This method returns the number of work hours between two datetimes.

It seems to be used by [odoo while computing theorical hours](https://github.com/OCA/OCB/blob/17.0/addons/hr_holidays/models/hr_leave.py#L588) in case of company hollidays (not related to an employee).

It's used by hr_attendance_validation (using this PR: https://github.com/OCA/hr-attendance/pull/180 on v14.0) used to compute the theoretical number of hours to works for the given date range.

I'm currently migrating those modules to v17.0

