### PR TITLE
[14.0][FIX] hr_holidays_security: Allow a user with the All Approver permission to be able to select any employee in allocations

### DIFF
--- a/hr_holidays_security/views/hr_leave_allocation_views.xml
+++ b/hr_holidays_security/views/hr_leave_allocation_views.xml
@@ -35,4 +35,24 @@
             </field>
         </field>
     </record>
+    <record id="hr_leave_allocation_view_form_user" model="ir.ui.view">
+        <field name="model">hr.leave.allocation</field>
+        <field
+            name="inherit_id"
+            ref="hr_holidays_security.hr_leave_allocation_view_form_manager"
+        />
+        <field
+            name="groups_id"
+            eval="[(4, ref('hr_holidays.group_hr_holidays_user'))]"
+        />
+        <field name="arch" type="xml">
+            <!-- It is important to leave the employee's domain empty so that the user with
+            the All Approver permission can see all employees and select any of
+            them. !-->
+            <field name="employee_id" position="attributes">
+                <attribute name="domain" />
+            </field>
+
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Allow a user with the All Approver permission to be able to select any employee in allocations.

Please @pilarvargas-tecnativa and @juancarlosonate-tecnativa can you review it?

@Tecnativa TT56361