### PR TITLE
[16.0][FIX] hr_holidays_public: records with archived users as followers

### DIFF
--- a/hr_holidays_public/models/res_partner.py
+++ b/hr_holidays_public/models/res_partner.py
@@ -11,6 +11,7 @@ class ResPartner(models.Model):
         res = super()._compute_im_status()
         for item in self.filtered(
             lambda x: x.user_ids.employee_id.is_public_holiday
+            and x.im_status != "im_partner"
             and "leave_" not in x.im_status
         ):
             item.im_status = (


### PR DESCRIPTION
Before this fix, opening a record could raise an error if **one of its chatter participants was a partner linked to an archived user, in case of public holiday for that user.** We get a key error: `KeyError: 'im_partner'`

This happened because the method `_get_im_status_hr_holidays_public` was being called without verifying whether the `im_status` field was `"im_partner"`. In some cases, even though the related user was archived, the expression `x.user_ids.employee_id.is_public_holiday` could still evaluate to True, triggering the method, and ultimately causing the error.

It fixes some changes introduced in #196.