### PR TITLE
[17.0][FIX] hr_holidays_public: Apply the appropriate domain to display public holidays

### DIFF
--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -65,13 +65,7 @@ class HrLeave(models.Model):
             else self.env.user.employee_id
         )
         if date_to:
-            domain.append(
-                (
-                    "date",
-                    "<",
-                    date_to,
-                )
-            )
+            domain.append(("date", "<=", date_to))
         country_id = employee.address_id.country_id.id
         if not country_id:
             country_id = self.env.company.country_id.id or False


### PR DESCRIPTION
FWP from 16.0: https://github.com/OCA/hr-holidays/pull/216

Apply the appropriate domain to display public holidays

Example use case:
- Define two dates as public holidays: 2025-12-30 + 2025-12-31
- Go to the Time off dashboard
- Both dates (2025-12-30 + 2025-12-31) should be displayed as Public Holidays

Please @pedrobaeza and @david-banon-tecnativa can you review it?

@Tecnativa TT58183