### PR TITLE
[15.0][FIX] hr_holidays_public: Apply the appropriate domain to display public holidays

### DIFF
--- a/hr_holidays_calendar_event_privacy/tests/test_hr_leave_calendar_event.py
+++ b/hr_holidays_calendar_event_privacy/tests/test_hr_leave_calendar_event.py
@@ -15,6 +15,7 @@ class TestHrLeaveCalendarEvent(TransactionCase):
         super().setUpClass()
         cls.admin_user = cls.env.ref("base.user_admin")
         cls.leave_type = cls.env.ref("hr_holidays.holiday_status_cl")
+        cls.leave_type.requires_allocation = "no"
 
     @classmethod
     def _new_leave_request(cls, date_from, date_to):

--- a/hr_holidays_public/models/hr_leave.py
+++ b/hr_holidays_public/models/hr_leave.py
@@ -62,13 +62,7 @@ class HrLeave(models.Model):
         ) == "hr.employee" and self.env.context.get("active_id"):
             employee = self.env["hr.employee"].browse(self.env.context.get("active_id"))
         if date_to:
-            domain.append(
-                (
-                    "date",
-                    "<",
-                    date_to,
-                )
-            )
+            domain.append(("date", "<=", date_to))
         country_id = employee.address_id.country_id.id
         if not country_id:
             country_id = self.env.company.country_id.id or False


### PR DESCRIPTION
Backport from 16.0: https://github.com/OCA/hr-holidays/pull/216

Apply the appropriate domain to display public holidays

Example use case:
- Define two dates as public holidays: 2025-12-30 + 2025-12-31
- Go to the Time off dashboard
- Both dates (2025-12-30 + 2025-12-31) should be displayed as Public Holidays

Please @pedrobaeza and @david-banon-tecnativa can you review it?

@Tecnativa TT58183