### PR TITLE
[18.0][FIX] hr_holidays_natural_period: not expect a singleton

### DIFF
--- a/hr_holidays_natural_period/models/hr_leave.py
+++ b/hr_holidays_natural_period/models/hr_leave.py
@@ -2,6 +2,8 @@
 # Copyright 2024 Tecnativa - Carlos Lopez
 # Copyright 2025 Grupo Isonor - Alexandre D. Díaz
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
+from collections import defaultdict
+
 from odoo import models
 
 
@@ -12,28 +14,50 @@ class HrLeave(models.Model):
         # We need to set request_unit as 'day'
         # to avoid the calculations being done as hours.
         mod_holidays_status_ids = self.env.context.get("mod_holidays_status_ids", [])
-        old_request_unit = self.holiday_status_id.request_unit
         natural_day_instances = self.filtered(
             lambda x: x.holiday_status_id.id in mod_holidays_status_ids
             or x.holiday_status_id.request_unit
             in ("natural_day", "natural_day_half_day")
         )
-        natural_day_instances.holiday_status_id.sudo().request_unit = (
-            "half_day" if old_request_unit == "natural_day_half_day" else "day"
-        )
         _self = self - natural_day_instances
-        _self = _self.with_context(old_request_unit=old_request_unit)
         res = super(HrLeave, _self)._get_durations(
             check_leave_type=check_leave_type, resource_calendar=resource_calendar
         )
         if not natural_day_instances:
             return res
-        _res = super(
-            HrLeave, natural_day_instances.with_context(natural_period=True)
-        )._get_durations(
-            check_leave_type=check_leave_type, resource_calendar=resource_calendar
-        )
-        for item in natural_day_instances:
-            res[item.id] = _res[item.id]
-        natural_day_instances.holiday_status_id.sudo().request_unit = old_request_unit
+        leaves_by_hs = defaultdict(lambda: self.env["hr.leave"])
+        for natural_day in natural_day_instances:
+            hs_id = natural_day.holiday_status_id
+            leaves_by_hs[hs_id] += natural_day
+        for holiday_status_id, leaves in leaves_by_hs.items():
+            orig_request_unit = holiday_status_id.request_unit
+            new_request_unit = (
+                "half_day" if orig_request_unit == "natural_day_half_day" else "day"
+            )
+            # FIXME: The field is updated in this way to prevent infinite recursion.
+            self.env.cache.update_raw(
+                holiday_status_id,
+                holiday_status_id._fields["request_unit"],
+                [new_request_unit],
+                dirty=True,
+            )
+            _leaves = leaves.with_context(
+                **{
+                    "natural_period": True,
+                    "old_request_unit": orig_request_unit,
+                }
+            )
+            _res = super(
+                HrLeave,
+                _leaves,
+            )._get_durations(
+                check_leave_type=check_leave_type, resource_calendar=resource_calendar
+            )
+            res.update(_res)
+            self.env.cache.update_raw(
+                holiday_status_id,
+                holiday_status_id._fields["request_unit"],
+                [orig_request_unit],
+                dirty=True,
+            )
         return res


### PR DESCRIPTION
"self" can be a recordset with more than one record. This can generate a recordset with more than one record for "self.holiday_status_id" This causes a singleton exception when retrieving the “request_unit” value. This also causes problems when sending the "original/old" value to the context... because it will be applying the same context to all "holiday_status_id" that may have different ‘request_unit’.
