### PR TITLE
[16.0][FIX] hr_holidays_leave_auto_approve: fix test w/ new validation

### DIFF
--- a/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
+++ b/hr_holidays_leave_auto_approve/tests/test_hr_holidays_leave_auto_approve.py
@@ -65,6 +65,8 @@ class TestHolidaysAutoValidate(TransactionCase):
     def test_leave_requests_state(self):
 
         today = datetime.today()
+        while today.weekday() >= 5:
+            today += timedelta(days=1)
 
         # Create leave requests for Leave Type1 and 2
         leave1 = self.leave_request_model.create(
@@ -98,6 +100,8 @@ class TestHolidaysAutoValidate(TransactionCase):
     def test_leave_requests_state_employee_user(self):
 
         today = datetime.today()
+        while today.weekday() >= 5:
+            today += timedelta(days=1)
 
         # Create leave requests for Leave Type1 and 2
         leave1 = self.leave_request_model.with_user(self.test_user_id).create(


### PR DESCRIPTION
Unit test tested function asking for a leave using datetime.today.
If CI was run in saturday or sunday, asking for a leave raised a ValidationError as it is not a working day.

I modified the test to be sure that selected day is between monday and friday, making test to be valid also when run on weekends

Fixes #230 intermittent error