### PR TITLE
[18.0][FIX] hr_holidays_public: Avoid failing computation of im_status

### DIFF
--- a/hr_holidays_public/models/hr_employee.py
+++ b/hr_holidays_public/models/hr_employee.py
@@ -64,7 +64,7 @@ class HrEmployeeBase(models.AbstractModel):
             "away": "leave_away",
             "offline": "leave_offline",
         }
-        return im_status_mapped[key]
+        return im_status_mapped.get(key, key)
 
     def _compute_leave_status(self):
         res = super()._compute_leave_status()


### PR DESCRIPTION
In case module hr_homeworking is installed, we can have different values for field res.users.im_status than those defined in function hr.employee.base._get_im_status_hr_holidays_public.

Therefore, any computation with such a value (eg presence_home_online) would result in a KeyError since the dict keys are accessed directly.

By using get and providing the same value as default in case the actual im_status is not defined we ensure the computation will not fail, even if any other module defines potentially new im_status values.