### PR TITLE
[18.0][FIX] hr_holidays_natural_period: Performance problem on number_of_days

### DIFF
--- a/hr_holidays_natural_period/models/hr_employee.py
+++ b/hr_holidays_natural_period/models/hr_employee.py
@@ -1,5 +1,6 @@
 # Copyright 2024 APSL-Nagarro - Antoni Marroig Campomar
 # Copyright 2025 Grupo Isonor - Alexandre D. Díaz
+# Copyright 2026 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
 from odoo import models
@@ -9,20 +10,24 @@ class HrEmployee(models.Model):
     _inherit = "hr.employee"
 
     def _get_consumed_leaves(self, leave_types, target_date=False, ignore_future=False):
-        """We need to set request_unit as 'day' to avoid the calculations being done
-        as hours.
-        """
+        # We need to set request_unit as day/half_day to avoid incorrect _check_validity
         mod_leave_type_ids = self.env["hr.leave.type"]
         leave_types_data = {}
         for item in leave_types:
             if item.request_unit in ("natural_day", "natural_day_half_day"):
                 leave_types_data[item] = item.request_unit
-                item.sudo().request_unit = (
+                new_request_unit = (
                     "half_day" if item.request_unit == "natural_day_half_day" else "day"
+                )
+                # HACK: The field is updated in this way to prevent recomputations
+                self.env.cache.update_raw(
+                    item, item._fields["request_unit"], [new_request_unit], dirty=True
                 )
                 mod_leave_type_ids |= item
         self = self.with_context(mod_holidays_status_ids=mod_leave_type_ids.ids)
         res = super()._get_consumed_leaves(leave_types, target_date, ignore_future)
         for item in mod_leave_type_ids:
-            item.sudo().request_unit = leave_types_data[item]
+            self.env.cache.update_raw(
+                item, item._fields["request_unit"], [leave_types_data[item]], dirty=True
+            )
         return res

--- a/hr_holidays_natural_period/models/hr_leave.py
+++ b/hr_holidays_natural_period/models/hr_leave.py
@@ -1,6 +1,7 @@
 # Copyright 2020-2025 Tecnativa - Víctor Martínez
 # Copyright 2024 Tecnativa - Carlos Lopez
 # Copyright 2025 Grupo Isonor - Alexandre D. Díaz
+# Copyright 2026 Tecnativa - Pedro M. Baeza
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 from collections import defaultdict
 
@@ -11,53 +12,49 @@ class HrLeave(models.Model):
     _inherit = "hr.leave"
 
     def _get_durations(self, check_leave_type=True, resource_calendar=None):
-        # We need to set request_unit as 'day'
-        # to avoid the calculations being done as hours.
+        # Inject context for getting the proper computation in
+        # resource.calendar~_attendance_intervals_batch
         mod_holidays_status_ids = self.env.context.get("mod_holidays_status_ids", [])
         natural_day_instances = self.filtered(
             lambda x: x.holiday_status_id.id in mod_holidays_status_ids
             or x.holiday_status_id.request_unit
             in ("natural_day", "natural_day_half_day")
         )
-        _self = self - natural_day_instances
-        res = super(HrLeave, _self)._get_durations(
+        res = super(HrLeave, self - natural_day_instances)._get_durations(
             check_leave_type=check_leave_type, resource_calendar=resource_calendar
         )
         if not natural_day_instances:
             return res
         leaves_by_hs = defaultdict(lambda: self.env["hr.leave"])
         for natural_day in natural_day_instances:
-            hs_id = natural_day.holiday_status_id
-            leaves_by_hs[hs_id] += natural_day
-        for holiday_status_id, leaves in leaves_by_hs.items():
-            orig_request_unit = holiday_status_id.request_unit
+            leaves_by_hs[natural_day.holiday_status_id] += natural_day
+        for holiday_status, leaves in leaves_by_hs.items():
+            orig_request_unit = holiday_status.request_unit
             new_request_unit = (
                 "half_day" if orig_request_unit == "natural_day_half_day" else "day"
             )
-            # FIXME: The field is updated in this way to prevent infinite recursion.
-            self.env.cache.update_raw(
-                holiday_status_id,
-                holiday_status_id._fields["request_unit"],
-                [new_request_unit],
-                dirty=True,
-            )
+            # We need to set request_unit as day/half_day to avoid incorrect
+            # _check_validity
+            # HACK: The field is updated in this way to prevent infinite recursion.
+            if holiday_status.id not in mod_holidays_status_ids:
+                self.env.cache.update_raw(
+                    holiday_status,
+                    holiday_status._fields["request_unit"],
+                    [new_request_unit],
+                    dirty=True,
+                )
             _leaves = leaves.with_context(
-                **{
-                    "natural_period": True,
-                    "old_request_unit": orig_request_unit,
-                }
+                natural_period=True, old_request_unit=orig_request_unit
             )
-            _res = super(
-                HrLeave,
-                _leaves,
-            )._get_durations(
+            _res = super(HrLeave, _leaves)._get_durations(
                 check_leave_type=check_leave_type, resource_calendar=resource_calendar
             )
             res.update(_res)
-            self.env.cache.update_raw(
-                holiday_status_id,
-                holiday_status_id._fields["request_unit"],
-                [orig_request_unit],
-                dirty=True,
-            )
+            if holiday_status.id not in mod_holidays_status_ids:
+                self.env.cache.update_raw(
+                    holiday_status,
+                    holiday_status._fields["request_unit"],
+                    [orig_request_unit],
+                    dirty=True,
+                )
         return res


### PR DESCRIPTION
When opening an employee that has leaves with natural days, and having a lot of leaves of this type for all the employees, there's a serious performance problem, because changing the request unit recomputes all the leaves of that type.

Using the trick from #60256 of updating just the cache with the desired value for the computations, avoid heavy recomputations.
    
This has uncovered also a problem of when the request unit is injected, so we reduce it to the minimum to avoid cross-changes.
    
@Tecnativa TT60256