### PR TITLE
[17.0][FIX] hr_holidays_settings: fix OwlError in settings view with empty container

### DIFF
--- a/hr_holidays_settings/views/res_config_settings.xml
+++ b/hr_holidays_settings/views/res_config_settings.xml
@@ -15,6 +15,7 @@
                         title="Leaves Management"
                         name="leaves_management_setting_container"
                     >
+                    <setting class="d-none" />
                     </block>
                 </app>
             </xpath>


### PR DESCRIPTION

<img width="1747" height="854" alt="image" src="https://github.com/user-attachments/assets/237399b5-7a03-4a3f-9ab5-6736920a1ee2" />

When debug mode is enabled and we click on **Leaves Management**, an Owl error is raised:

```
OwlError: Invalid props for component 'SettingsBlock': 'slots' is missing (should be a object)
    at Object.validateProps (http://...)
    at SettingsFormRenderer.slot92 (eval at compile (...))
    at callSlot (http://...)
    at SettingsApp.template (eval at compile (...))
    at Fiber._render (http://...)
    at Fiber.render (http://...)
    at ComponentNode.updateAndRender (http://...)
```

## Reproduction

The error can be reproduced in Runboat. It was reported during the migration to v17 (see [this comment](https://github.com/OCA/hr-holidays/pull/154#pullrequestreview-2491355722)).

A similar issue was reported in odoo/odoo#194746, but the proposed solution did not work.

## Root Cause

The issue likely stems from a settings container block that has no actual settings. I suspect this should not be a concern for instances with add-ons extending this specific view.

## Purpose of This PR

The fix proposed here is really a **workaround**. This PR aims to start a conversation, with the goal of finding a better, more robust approach.

@BinhexTeam T12289