### PR TITLE
[17.0][FIX] hr_holidays_public: Map hr_homeworking im_status values and use…

### DIFF
--- a/hr_holidays_public/models/hr_employee.py
+++ b/hr_holidays_public/models/hr_employee.py
@@ -64,7 +64,13 @@ class HrEmployeeBase(models.AbstractModel):
             "away": "leave_away",
             "offline": "leave_offline",
         }
-        return im_status_mapped[key]
+        if key in im_status_mapped:
+            return im_status_mapped[key]
+        if key.endswith("_online"):
+            return "leave_online"
+        if key.endswith("_away"):
+            return "leave_away"
+        return "leave_offline"
 
     def _compute_leave_status(self):
         res = super()._compute_leave_status()


### PR DESCRIPTION
Problem
When hr_homeworking is installed, it prefixes im_status with the location type (e.g. office_offline, home_online). This causes a KeyError in _get_im_status_hr_holidays_public since the dict only contains the base values (online, away, offline).
The fix in commit 7284212 used .get(key, key) which avoids the error but returns the raw unprefixed value, breaking downstream logic that expects a leave_* value.

Fix
Check first against the base dict, then use endswith to safely detect prefixed variants from hr_homeworking or any other module, falling back to leave_offline for any unknown state.

@grindtildeath 