### PR TITLE
[16.0][IMP] hr_holidays_public: remove redundant partner resolution in is_public_holiday

### DIFF
--- a/hr_holidays_public/models/hr_holidays_public.py
+++ b/hr_holidays_public/models/hr_holidays_public.py
@@ -111,7 +111,6 @@ class HrHolidaysPublic(models.Model):
             start_dt,
             end_dt,
             partner_id=partner_id,
-            employee_id=employee_id,
         )
         hhplo = self.env["hr.holidays.public.line"]
         holidays_lines = hhplo.search(states_filter)
@@ -126,8 +125,6 @@ class HrHolidaysPublic(models.Model):
         :param partner_id: ID of the partner
         :return: bool
         """
-        partner = self._get_partner_deprecated_employee(partner_id, employee_id)
-        partner_id = partner.id if partner else None
         holidays_lines = self.get_holidays_list(
             year=selected_date.year, partner_id=partner_id, employee_id=employee_id
         )


### PR DESCRIPTION
Simplify is_public_holiday by removing the redundant call to _get_partner_deprecated_employee, as it is already invoked immediately after inside get_holidays_list: 

So we correct the Warning:
<img width="1727" height="38" alt="image" src="https://github.com/user-attachments/assets/a553351e-b761-459d-b180-53804c088cfb" />
