### PR TITLE
[19.0][FIX] hr_holidays_public: adapt tests to out-of-contract unusual days

### DIFF
--- a/hr_holidays_public/tests/test_holidays_public.py
+++ b/hr_holidays_public/tests/test_holidays_public.py
@@ -24,10 +24,16 @@ class TestHolidaysPublic(TestCalendarPublicHoliday):
         cls.st_state_2 = cls.env["res.country.state"].create(
             {"name": "ST State 2", "code": "st", "country_id": cls.country_1.id}
         )
+        # A running contract is required: since odoo/odoo@45c601bf,
+        # get_unusual_days() returns True for every day outside of the
+        # employee's contracts, which would make the tested dates unusual
+        # regardless of the public holidays.
         cls.employee = cls.employee_model.create(
             {
                 "name": "Employee 1",
                 "address_id": cls.res_partner.id,
+                "date_version": "2019-01-01",
+                "contract_date_start": "2019-01-01",
             }
         )
 


### PR DESCRIPTION
## Problem

On current 19.0, the 10 `TestHolidaysPublic` tests that go through
`assertPublicHolidayIsUnusualDay` fail with:

    File "hr_holidays_public/tests/test_holidays_public.py", line 37, in assertPublicHolidayIsUnusualDay
        self.assertFalse(
    AssertionError: True is not false

The failing assertion is the *baseline* one, evaluated before any public holiday is
created: `2019-07-30` (a Tuesday) is already reported as an unusual day.

## Cause

odoo/odoo@45c601bf ([odoo/odoo#258038](https://github.com/odoo/odoo/pull/258038),
merged 2026-08-04) changed `_get_unusual_days`:

> made `_get_unusual_days` return True for all the days outside of contracts for
> the employee instead of not returning anything for them or getting values from
> the working schedule of the employee

The test employee is created without any contract, so every date is now
out-of-contract and therefore unusual, regardless of public holidays. Odoo adapted
its own tests the same way in that commit (`addons/hr/tests/test_hr_employee.py`
gained `date_version` / `contract_date_start`).

## Fix

Give the test employee a running contract covering the tested dates:

```python
out-of-contract and therefore unusual, regardless of public holidays. Odoo adapted
its own tests the same way in that commit (`addons/hr/tests/test_hr_employee.py`
gained `date_version` / `contract_date_start`).

## Fix

Give the test employee a running contract covering the tested dates:

```python
cls.employee = cls.employee_model.create(
    {
        "name": "Employee 1",
        "address_id": cls.res_partner.id,
        "date_version": "2019-01-01",
        "contract_date_start": "2019-01-01",
    }
)

Test-only change. No production behaviour of hr_holidays_public is affected — its
get_unusual_days override still only adds public holidays on top of super().