### PR TITLE
[19.0][FIX] hr_holidays_public: use public employee work address

### DIFF
--- a/hr_holidays_public/models/resource_calendar.py
+++ b/hr_holidays_public/models/resource_calendar.py
@@ -18,7 +18,7 @@ class ResourceCalendar(models.Model):
         employee_id = self.env.context.get("employee_id", False)
         if not employee_id:
             return intervals
-        employee = self.env["hr.employee"].browse(employee_id)
+        employee = self.env["hr.employee.public"].browse(employee_id)
         list_by_dates = (
             self.env["calendar.public.holiday"]
             .get_holidays_list(

--- a/hr_holidays_public/tests/test_holidays_calculation.py
+++ b/hr_holidays_public/tests/test_holidays_calculation.py
@@ -4,6 +4,8 @@
 # Copyright 2020 InitOS Gmbh
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from odoo.tests import new_test_user
+
 from odoo.addons.calendar_public_holiday.tests.test_calendar_public_holiday import (
     TestCalendarPublicHoliday,
 )
@@ -65,6 +67,13 @@ class TestHolidaysComputeDaysBase(TestCalendarPublicHoliday):
                 "address_id": cls.address_2.id,
             }
         )
+        cls.employee_user = new_test_user(
+            cls.env,
+            login="public_holiday_employee",
+            groups="base.group_user",
+            name="Employee 2",
+        )
+        cls.employee_2.user_id = cls.employee_user
         # Use a very old year for avoiding to collapse with current data
         cls.public_holiday_global = cls.holiday_model.create(
             {
@@ -178,4 +187,17 @@ class TestHolidaysComputeDays(TestHolidaysComputeDaysBase):
                 "employee_id": self.employee_2.id,
             }
         )
+        self.assertEqual(leave_request.number_of_days, 2)
+
+    def test_number_days_excluding_as_employee_user(self):
+        """Test an employee user excludes holidays using its public work address."""
+        leave_request = self.HrLeave.with_user(self.employee_user).new(
+            {
+                "date_from": "1946-12-23 00:00:00",  # Monday
+                "date_to": "1946-12-29 23:59:59",  # Sunday
+                "holiday_status_id": self.holiday_type.id,
+                "employee_id": self.employee_2.id,
+            }
+        )
+
         self.assertEqual(leave_request.number_of_days, 2)


### PR DESCRIPTION
Read the employee work address through `hr.employee.public` when excluding public holidays from attendance intervals.

This avoids implicitly accessing the protected `hr.version` record when leave durations are computed by an employee user.